### PR TITLE
Webring: urls field and random redirection script

### DIFF
--- a/hasard.php
+++ b/hasard.php
@@ -1,0 +1,19 @@
+<?php
+
+const WEBRING_JSON = 'webring.json';
+const ERROR_TARGET = 'https://club1.fr';
+
+if (!file_exists(WEBRING_JSON)) {
+    header('Location: ' . ERROR_TARGET);
+    die;
+}
+
+$webring = json_decode(file_get_contents(WEBRING_JSON));
+if (empty($webring['urls'])) {
+    header('Location: ' . ERROR_TARGET);
+    die;
+}
+
+$target = $webring['urls'][random_int(0, count($webring['urls']))];
+header('Location: ' . $target);
+

--- a/hasard.php
+++ b/hasard.php
@@ -4,13 +4,13 @@ const WEBRING_JSON = 'webring.json';
 const ERROR_TARGET = 'https://club1.fr';
 
 if (!file_exists(WEBRING_JSON)) {
-    header('Location: ' . ERROR_TARGET);
+	http_response_code(500);
     die;
 }
 
 $webring = json_decode(file_get_contents(WEBRING_JSON));
 if (empty($webring['urls'])) {
-    header('Location: ' . ERROR_TARGET);
+	http_response_code(500);
     die;
 }
 

--- a/hasard.php
+++ b/hasard.php
@@ -14,6 +14,6 @@ if (empty($webring['urls'])) {
     die;
 }
 
-$target = $webring['urls'][random_int(0, count($webring['urls']))];
+$target = $webring['urls'][random_int(0, count($webring['urls']) - 1)];
 header('Location: ' . $target);
 

--- a/index.php
+++ b/index.php
@@ -116,8 +116,8 @@ function renderUsers()
                     if (!empty($frontMatter['color'])) {
                         $color = $frontMatter['color'];
                     }
-                    if (!empty($frontMatter['urls'])) {
-                        $urls = $frontMatter['urls'];
+                    if (!empty($frontMatter['websites'])) {
+                        $urls = $frontMatter['websites'];
                         if (is_string($urls)) {
                             $webringUrls[] = $urls;
                         } elseif (is_array($urls)) {

--- a/index.php
+++ b/index.php
@@ -119,9 +119,10 @@ function renderUsers()
                     if (!empty($frontMatter['urls'])) {
                         $urls = $frontMatter['urls'];
                         if (is_string($urls)) {
-                            $urls = [$urls];
+                            $webringUrls[] = $urls;
+                        } elseif (is_array($urls)) {
+                            $webringUrls = array_merge($webringUrls, array_values($urls));
                         }
-                        $webringUrls = array_merge($webringUrls, array_values($urls));
                     }
                 }
             } catch (RuntimeException $e) {

--- a/index.php
+++ b/index.php
@@ -118,9 +118,7 @@ function renderUsers()
                     }
                     if (!empty($frontMatter['websites'])) {
                         $urls = $frontMatter['websites'];
-                        if (is_string($urls)) {
-                            $webringUrls[] = $urls;
-                        } elseif (is_array($urls)) {
+                        if (is_array($urls)) {
                             $webringUrls = array_merge($webringUrls, array_values($urls));
                         }
                     }

--- a/index.php
+++ b/index.php
@@ -134,7 +134,6 @@ function renderUsers()
             $renderedCounter ++;
         }
     }
-    shuffle($webringUrls);
 }
 
 if ($needRender) {

--- a/index.php
+++ b/index.php
@@ -6,6 +6,7 @@ require __DIR__ . '/vendor/autoload.php';
 
 const CACHE_FILE    = 'cache.html';
 const CACHE_JSON    = 'cache.json';
+const WEBRING_JSON  = 'webring.json';
 const DEFAULT_COLOR = '#35a0d6';
 $needRender         = false;
 $renderedCounter    = 0;
@@ -21,6 +22,7 @@ if (!file_exists(CACHE_FILE)) {
 }
 
 $users = array_diff(scandir('/home'), array('..', '.'));
+$webringUrls = [];
 
 use League\CommonMark\Environment\Environment;
 use League\CommonMark\Extension\CommonMark\CommonMarkCoreExtension;
@@ -95,6 +97,7 @@ function renderUsers()
     global $converter;
     global $users;
     global $renderedCounter;
+    global $webringUrls;
     shuffle($users);
     foreach ($users as $user) {
         $presentation = presentationDir($user);
@@ -113,6 +116,13 @@ function renderUsers()
                     if (!empty($frontMatter['color'])) {
                         $color = $frontMatter['color'];
                     }
+                    if (!empty($frontMatter['urls'])) {
+                        $urls = $frontMatter['urls'];
+                        if (is_string($urls)) {
+                            $urls = [$urls];
+                        }
+                        $webringUrls = array_merge($webringUrls, array_values($urls));
+                    }
                 }
             } catch (RuntimeException $e) {
                 $message = $e->getMessage();
@@ -123,6 +133,7 @@ function renderUsers()
             $renderedCounter ++;
         }
     }
+    shuffle($webringUrls);
 }
 
 if ($needRender) {
@@ -137,10 +148,9 @@ if ($needRender) {
     if (is_string($render)) {
         file_put_contents(CACHE_FILE, $render);
         file_put_contents(CACHE_JSON, json_encode(['renderedCounter' => $renderedCounter]));
+        file_put_contents(WEBRING_JSON, json_encode(['urls' => $webringUrls]);
     }
 }
 
-include 'cache.html';
+include CACHE_FILE;
 
-
-?>


### PR DESCRIPTION
PRESENTATION.md gets a new front matter tag, 'urls', a YAML array.

```markdown
---
name: Jirsad Cassam
urls:
  - https://www.cassam.fr
  - https://snac.cassam.fr
---
bla bla bla
```

Gathered URLs are printed into `webring.json` as:

```json
{
  "urls": [
    "https://www.cassam.fr",
    "https://snac.cassam.fr"
  ]
}
```

Random redirection available now at `./hasard.php`

On error, if `webring.json` cannot be open or is empty, `hasard.php` will return a HTTP 500 code.